### PR TITLE
Automated constructors based on public fields

### DIFF
--- a/.github/workflows/golang-test-annotations.yml
+++ b/.github/workflows/golang-test-annotations.yml
@@ -10,7 +10,7 @@ jobs:
   full_ci:
     strategy:
       matrix:
-        go-version: [ 1.15.x ]
+        go-version: [ 1.19.x ]
 
     runs-on: ubuntu-18.04
 

--- a/.github/workflows/golang-test-annotations.yml
+++ b/.github/workflows/golang-test-annotations.yml
@@ -23,6 +23,6 @@ jobs:
 
       - name: Annotate tests
         if: always()
-        uses: guyarb/golang-test-annotations@v0.3.0
+        uses: guyarb/golang-test-annotations@v0.6.0
         with:
           test-results: test.json

--- a/.github/workflows/golang-test-annotations.yml
+++ b/.github/workflows/golang-test-annotations.yml
@@ -10,19 +10,25 @@ jobs:
   full_ci:
     strategy:
       matrix:
-        go-version: [ 1.19.x ]
+        go_version: [ 1.18.x ]
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - name: checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go_version }}
+        
       - name: run tests
-        run: go test -count=500 -failfast -race -json ./... > test.json
+        run: go test -json ./... > test.json
 
       - name: Annotate tests
         if: always()
-        uses: guyarb/golang-test-annotations@v0.6.0
+        uses: guyarb/golang-test-annotations@v0.5.1
         with:
           test-results: test.json
+          package-name: tinysl

--- a/README.md
+++ b/README.md
@@ -67,6 +67,6 @@ func MyRequestHandler(w http.ResponseWriter, req *http.Request) {
  * `func(context.Context, T1, T2, ...) (T, error)` - for PerContext and Transient only    
 
 ### Public fields constructor
- * `tinysl.T[Type]` - would return Type instance with filled public fields using registered constructors.
- * `tinysl.P[Type]` - would return *Type instance with filled public fields using registered constructors.
- * 	`tinysl.I[Interface, Type]` - would return Interface implemented by *Type instance with filled public fields using registered constructors.
+ * `tinysl.T[Type]` - would return `Type` instance with filled public fields using registered constructors.
+ * `tinysl.P[Type]` - would return `*Type` instance with filled public fields using registered constructors.
+ * 	`tinysl.I[Interface, Type]` - would return `Interface` implemented by `*Type` instance with filled public fields using registered constructors.

--- a/README.md
+++ b/README.md
@@ -63,5 +63,10 @@ func MyRequestHandler(w http.ResponseWriter, req *http.Request) {
  * `tinysl.Transient`
 
 ### Constructor types that can be used:
- * `func(T1, T2, ...) (T, error)                // for PerContext, Transient and Singleton`
- * `func(context.Context, T1, T2, ...) (T, error) // for PerContext and Transient only    `
+ * `func(T1, T2, ...) (T, error)` - for PerContext, Transient and Singleton
+ * `func(context.Context, T1, T2, ...) (T, error)` - for PerContext and Transient only    
+
+### Public fields constructor
+ * `tinysl.T[Type]` - would return Type instance with filled public fields using registered constructors.
+ * `tinysl.P[Type]` - would return *Type instance with filled public fields using registered constructors.
+ * 	`tinysl.I[Interface, Type]` - would return Interface implemented by *Type instance with filled public fields using registered constructors.

--- a/constructor.go
+++ b/constructor.go
@@ -8,8 +8,9 @@ type propertyFiller struct {
 	NewInstance  func(values ...any) (any, error)
 }
 
-func T[T any]() (propertyFiller, error) {
-	t := reflect.TypeOf(new(T)).Elem()
+// Type constructor that would automatically fill public fields using registered constructors.
+func T[Type any]() (propertyFiller, error) {
+	t := reflect.TypeOf(new(Type)).Elem()
 
 	if t.Kind() != reflect.Struct {
 		return propertyFiller{}, &TError{T: t}
@@ -30,14 +31,15 @@ func T[T any]() (propertyFiller, error) {
 	}
 
 	return propertyFiller{
-		Type:         reflect.TypeOf(new(T)).Elem(),
+		Type:         reflect.TypeOf(new(Type)).Elem(),
 		Dependencies: dependencies,
-		NewInstance:  getValueInstance[T](fields),
+		NewInstance:  getValueInstance[Type](fields),
 	}, nil
 }
 
-func P[T any]() (propertyFiller, error) {
-	t := reflect.TypeOf(new(T)).Elem()
+// *Type constructor that would automatically fill public fields using registered constructors.
+func P[Type any]() (propertyFiller, error) {
+	t := reflect.TypeOf(new(Type)).Elem()
 
 	if t.Kind() != reflect.Struct {
 		return propertyFiller{}, &PError{T: t}
@@ -58,16 +60,18 @@ func P[T any]() (propertyFiller, error) {
 	}
 
 	return propertyFiller{
-		Type:         reflect.TypeOf(new(T)),
+		Type:         reflect.TypeOf(new(Type)),
 		Dependencies: dependencies,
-		NewInstance:  getPointerInstance[T](fields),
+		NewInstance:  getPointerInstance[Type](fields),
 	}, nil
 }
 
-func I[I, T any]() (propertyFiller, error) {
-	p := reflect.TypeOf(new(T))
+// Interface constructor that would use *Type as implementation
+// and automatically fill public fields using registered constructors.
+func I[Interface, Type any]() (propertyFiller, error) {
+	p := reflect.TypeOf(new(Type))
 	t := p.Elem()
-	i := reflect.TypeOf(new(I)).Elem()
+	i := reflect.TypeOf(new(Interface)).Elem()
 
 	if t.Kind() != reflect.Struct {
 		return propertyFiller{}, newIError(ErrIWrongTType, i, t)
@@ -96,9 +100,9 @@ func I[I, T any]() (propertyFiller, error) {
 	}
 
 	return propertyFiller{
-		Type:         reflect.TypeOf(new(I)).Elem(),
+		Type:         reflect.TypeOf(new(Interface)).Elem(),
 		Dependencies: dependencies,
-		NewInstance:  getPointerInstance[T](fields),
+		NewInstance:  getPointerInstance[Type](fields),
 	}, nil
 }
 

--- a/constructor.go
+++ b/constructor.go
@@ -1,0 +1,127 @@
+package tinysl
+
+import "reflect"
+
+type propertyFiller struct {
+	Type         reflect.Type
+	Dependencies []string
+	NewInstance  func(values ...any) (any, error)
+}
+
+func T[T any]() (propertyFiller, error) {
+	t := reflect.TypeOf(new(T)).Elem()
+
+	if t.Kind() != reflect.Struct {
+		return propertyFiller{}, &TError{T: t}
+	}
+
+	filedIndex := 0
+	fields := make(map[int]int)
+	dependencies := make([]string, 0, 1)
+
+	for i := 0; i < t.NumField(); i++ {
+		if !t.Field(i).IsExported() {
+			continue
+		}
+
+		dependencies = append(dependencies, t.Field(i).Type.String())
+		fields[filedIndex] = i
+		filedIndex++
+	}
+
+	return propertyFiller{
+		Type:         reflect.TypeOf(new(T)).Elem(),
+		Dependencies: dependencies,
+		NewInstance:  getValueInstance[T](fields),
+	}, nil
+}
+
+func P[T any]() (propertyFiller, error) {
+	t := reflect.TypeOf(new(T)).Elem()
+
+	if t.Kind() != reflect.Struct {
+		return propertyFiller{}, &PError{T: t}
+	}
+
+	filedIndex := 0
+	fields := make(map[int]int)
+	dependencies := make([]string, 0, 1)
+
+	for i := 0; i < t.NumField(); i++ {
+		if !t.Field(i).IsExported() {
+			continue
+		}
+
+		dependencies = append(dependencies, t.Field(i).Type.String())
+		fields[filedIndex] = i
+		filedIndex++
+	}
+
+	return propertyFiller{
+		Type:         reflect.TypeOf(new(T)),
+		Dependencies: dependencies,
+		NewInstance:  getPointerInstance[T](fields),
+	}, nil
+}
+
+func I[I, T any]() (propertyFiller, error) {
+	p := reflect.TypeOf(new(T))
+	t := p.Elem()
+	i := reflect.TypeOf(new(I)).Elem()
+
+	if t.Kind() != reflect.Struct {
+		return propertyFiller{}, newIError(ErrIWrongTType, i, t)
+	}
+
+	if i.Kind() != reflect.Interface {
+		return propertyFiller{}, newIError(ErrIWrongIType, i, t)
+	}
+
+	if !p.Implements(i) {
+		return propertyFiller{}, newIError(ErrITDoesNotImplementI, i, t)
+	}
+
+	filedIndex := 0
+	fields := make(map[int]int)
+	dependencies := make([]string, 0, 1)
+
+	for i := 0; i < t.NumField(); i++ {
+		if !t.Field(i).IsExported() {
+			continue
+		}
+
+		dependencies = append(dependencies, t.Field(i).Type.String())
+		fields[filedIndex] = i
+		filedIndex++
+	}
+
+	return propertyFiller{
+		Type:         reflect.TypeOf(new(I)).Elem(),
+		Dependencies: dependencies,
+		NewInstance:  getPointerInstance[T](fields),
+	}, nil
+}
+
+func getValueInstance[T any](fields map[int]int) func(...any) (any, error) {
+	return func(values ...any) (any, error) {
+		p := reflect.ValueOf(new(T)).Elem()
+
+		for i, v := range values {
+			p.Field(fields[i]).Set(reflect.ValueOf(v))
+		}
+
+		return p.Interface(), nil
+	}
+}
+
+func getPointerInstance[T any](fields map[int]int) func(...any) (any, error) {
+	return func(values ...any) (any, error) {
+		p := reflect.ValueOf(new(T)).Elem()
+
+		for i, v := range values {
+			p.Field(fields[i]).Set(reflect.ValueOf(v))
+		}
+
+		return p.Addr().Interface(), nil
+	}
+}

--- a/constructor_test.go
+++ b/constructor_test.go
@@ -1,0 +1,134 @@
+package tinysl_test
+
+import (
+	"reflect"
+
+	"github.com/andriiyaremenko/tinysl"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/pkg/errors"
+)
+
+var _ = Describe("Constructor", func() {
+	Context("T", func() {
+		It("should return error if type argument is not a struct", func() {
+			_, err := tinysl.T[int]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.TError)))
+
+			_, err = tinysl.T[string]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.TError)))
+
+			_, err = tinysl.T[*NameService]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.TError)))
+
+			_, err = tinysl.T[NameService]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.TError)))
+		})
+
+		It("should work with a struct type argument", func() {
+			constructor, err := tinysl.T[ServiceWithPublicFields]()
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(constructor.Type).
+				To(Equal(reflect.TypeOf(ServiceWithPublicFields{})))
+			Expect(constructor.Dependencies).
+				To(Equal([]string{"tinysl_test.NameService"}))
+		})
+	})
+
+	Context("P", func() {
+		It("should return error if type argument is not a struct", func() {
+			_, err := tinysl.P[int]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.PError)))
+
+			_, err = tinysl.P[string]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.PError)))
+
+			_, err = tinysl.P[*NameService]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.PError)))
+
+			_, err = tinysl.P[NameService]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.PError)))
+		})
+
+		It("should work with a struct type argument", func() {
+			constructor, err := tinysl.P[ServiceWithPublicFields]()
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(constructor.Type).
+				To(Equal(reflect.TypeOf(&ServiceWithPublicFields{})))
+			Expect(constructor.Dependencies).
+				To(Equal([]string{"tinysl_test.NameService"}))
+		})
+	})
+
+	Context("I", func() {
+		It("should return error if T type argument is not a struct", func() {
+			_, err := tinysl.I[int, int]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.IError)))
+			Expect(errors.Unwrap(err)).Should(MatchError(tinysl.ErrIWrongTType))
+
+			_, err = tinysl.I[string, string]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.IError)))
+			Expect(errors.Unwrap(err)).Should(MatchError(tinysl.ErrIWrongTType))
+
+			_, err = tinysl.I[NameService, *Hero]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.IError)))
+			Expect(errors.Unwrap(err)).Should(MatchError(tinysl.ErrIWrongTType))
+
+			_, err = tinysl.I[NameService, NameService]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.IError)))
+			Expect(errors.Unwrap(err)).Should(MatchError(tinysl.ErrIWrongTType))
+		})
+
+		It("should return error if I type argument is not an interface", func() {
+			_, err := tinysl.I[NameProvider, Impostor]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.IError)))
+			Expect(errors.Unwrap(err)).Should(MatchError(tinysl.ErrIWrongIType))
+		})
+
+		It("should return error if T type argument does not implement I type argument", func() {
+			_, err := tinysl.I[NameService, Hero]()
+
+			Expect(err).Should(HaveOccurred())
+			Expect(err).Should(BeAssignableToTypeOf(new(tinysl.IError)))
+			Expect(errors.Unwrap(err)).Should(MatchError(tinysl.ErrITDoesNotImplementI))
+		})
+
+		It("should work with when *T type argument implements I type argument", func() {
+			constructor, err := tinysl.I[HelloService, ServiceWithPublicFields]()
+
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(constructor.Type).
+				To(Equal(reflect.TypeOf(new(HelloService)).Elem()))
+			Expect(constructor.Dependencies).
+				To(Equal([]string{"tinysl_test.NameService"}))
+		})
+	})
+})

--- a/doc.go
+++ b/doc.go
@@ -57,6 +57,11 @@
 // 	tinysl.Transient
 //
 // Constructor types that can be used:
-// 	func(T1, T2, ...) (T, error)                // for PerContext, Transient and Singleton
-// 	func(context.Context, T1, T2, ...) (T, error) // for PerContext and Transient only
+//  * func(T1, T2, ...) (T, error) - for PerContext, Transient and Singleton
+//  * func(context.Context, T1, T2, ...) (T, error) - for PerContext and Transient only
+//
+// Public fields constructor
+//  * tinysl.T[Type] - would return Type instance with filled public fields using registered constructors.
+//  * tinysl.P[Type] - would return *Type instance with filled public fields using registered constructors.
+//  * tinysl.I[Interface, Type] - would return Interface implemented by *Type instance with filled public fields using registered constructors.
 package tinysl

--- a/locator_test.go
+++ b/locator_test.go
@@ -21,11 +21,11 @@ var _ = Describe("ServiceLocator", func() {
 
 		Expect(err).ShouldNot(HaveOccurred())
 
-		hero1, err := tinysl.Get[*hero](context.TODO(), sl)
+		hero1, err := tinysl.Get[*Hero](context.TODO(), sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 
-		hero2, err := tinysl.Get[*hero](context.TODO(), sl)
+		hero2, err := tinysl.Get[*Hero](context.TODO(), sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hero1).NotTo(BeIdenticalTo(hero2))
@@ -43,11 +43,11 @@ var _ = Describe("ServiceLocator", func() {
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
 
-		hero1, err := tinysl.Get[*hero](ctx, sl)
+		hero1, err := tinysl.Get[*Hero](ctx, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 
-		hero2, err := tinysl.Get[*hero](ctx, sl)
+		hero2, err := tinysl.Get[*Hero](ctx, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hero1).To(BeIdenticalTo(hero2))
@@ -68,11 +68,11 @@ var _ = Describe("ServiceLocator", func() {
 		defer cancel1()
 		defer cancel2()
 
-		hero1, err := tinysl.Get[*hero](ctx1, sl)
+		hero1, err := tinysl.Get[*Hero](ctx1, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 
-		hero2, err := tinysl.Get[*hero](ctx2, sl)
+		hero2, err := tinysl.Get[*Hero](ctx2, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hero1).NotTo(BeIdenticalTo(hero2))
@@ -90,7 +90,7 @@ var _ = Describe("ServiceLocator", func() {
 		ctx, cancel := context.WithCancel(ctx)
 		cancel()
 
-		_, err = tinysl.Get[*hero](ctx, sl)
+		_, err = tinysl.Get[*Hero](ctx, sl)
 
 		Expect(err).Should(HaveOccurred())
 		Expect(err).Should(BeAssignableToTypeOf(new(tinysl.ServiceBuilderError)))
@@ -105,7 +105,7 @@ var _ = Describe("ServiceLocator", func() {
 
 		Expect(err).ShouldNot(HaveOccurred())
 
-		_, err = tinysl.Get[*hero](nil, sl)
+		_, err = tinysl.Get[*Hero](nil, sl)
 
 		Expect(err).Should(HaveOccurred())
 		Expect(err).Should(BeAssignableToTypeOf(new(tinysl.ServiceBuilderError)))
@@ -124,11 +124,11 @@ var _ = Describe("ServiceLocator", func() {
 
 		defer cancel()
 
-		hero1, err := tinysl.Get[*hero](ctx1, sl)
+		hero1, err := tinysl.Get[*Hero](ctx1, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 
-		hero2, err := tinysl.Get[*hero](ctx2, sl)
+		hero2, err := tinysl.Get[*Hero](ctx2, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hero1).To(BeIdenticalTo(hero2))
@@ -145,17 +145,17 @@ var _ = Describe("ServiceLocator", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		ctx := context.TODO()
-		impostor, err := tinysl.Get[*impostor](ctx, sl)
+		impostor, err := tinysl.Get[*Impostor](ctx, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(impostor.Announce()).To(Equal("Bob is our hero!"))
 
-		hero, err := tinysl.Get[*hero](ctx, sl)
+		hero, err := tinysl.Get[*Hero](ctx, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(hero.Announce()).To(Equal("Bob is our hero!"))
 
-		nameService, err := tinysl.Get[nameService](ctx, sl)
+		nameService, err := tinysl.Get[NameService](ctx, sl)
 
 		Expect(err).ShouldNot(HaveOccurred())
 		Expect(nameService.Name()).To(Equal("Bob"))
@@ -171,7 +171,7 @@ var _ = Describe("ServiceLocator", func() {
 		Expect(err).ShouldNot(HaveOccurred())
 
 		ctx := context.TODO()
-		_, err = tinysl.Get[*impostor](ctx, sl)
+		_, err = tinysl.Get[*Impostor](ctx, sl)
 
 		Expect(err).Should(HaveOccurred())
 		Expect(err).Should(BeAssignableToTypeOf(new(tinysl.ConstructorNotFoundError)))
@@ -190,13 +190,13 @@ var _ = Describe("ServiceLocator", func() {
 			ctx1, cancel1 := context.WithCancel(ctx1)
 			ctx2, cancel2 := context.WithCancel(ctx1)
 
-			var hero1, hero2, hero3 *hero
+			var hero1, hero2, hero3 *Hero
 			var err1, err2, err3 error
 			var wg sync.WaitGroup
 
 			wg.Add(1)
 			go func() {
-				hero1, err1 = tinysl.Get[*hero](ctx1, sl)
+				hero1, err1 = tinysl.Get[*Hero](ctx1, sl)
 
 				Expect(err1).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -204,7 +204,7 @@ var _ = Describe("ServiceLocator", func() {
 
 			wg.Add(1)
 			go func() {
-				hero2, err2 = tinysl.Get[*hero](ctx2, sl)
+				hero2, err2 = tinysl.Get[*Hero](ctx2, sl)
 
 				Expect(err2).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -212,7 +212,7 @@ var _ = Describe("ServiceLocator", func() {
 
 			wg.Add(1)
 			go func() {
-				hero3, err3 = tinysl.Get[*hero](ctx1, sl)
+				hero3, err3 = tinysl.Get[*Hero](ctx1, sl)
 
 				Expect(err3).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -220,7 +220,7 @@ var _ = Describe("ServiceLocator", func() {
 
 			wg.Add(1)
 			go func() {
-				_, err = tinysl.Get[nameService](ctx1, sl)
+				_, err = tinysl.Get[NameService](ctx1, sl)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -251,13 +251,13 @@ var _ = Describe("ServiceLocator", func() {
 			ctx1, cancel1 := context.WithCancel(ctx1)
 			ctx2, cancel2 := context.WithCancel(ctx1)
 
-			var hero1, hero2, hero3 *hero
+			var hero1, hero2, hero3 *Hero
 			var err1, err2, err3 error
 			var wg sync.WaitGroup
 
 			wg.Add(1)
 			go func() {
-				hero1, err1 = tinysl.Get[*hero](ctx1, sl)
+				hero1, err1 = tinysl.Get[*Hero](ctx1, sl)
 
 				Expect(err1).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -265,7 +265,7 @@ var _ = Describe("ServiceLocator", func() {
 
 			wg.Add(1)
 			go func() {
-				hero2, err2 = tinysl.Get[*hero](ctx2, sl)
+				hero2, err2 = tinysl.Get[*Hero](ctx2, sl)
 
 				Expect(err2).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -273,7 +273,7 @@ var _ = Describe("ServiceLocator", func() {
 
 			wg.Add(1)
 			go func() {
-				hero3, err3 = tinysl.Get[*hero](ctx1, sl)
+				hero3, err3 = tinysl.Get[*Hero](ctx1, sl)
 
 				Expect(err3).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -281,7 +281,7 @@ var _ = Describe("ServiceLocator", func() {
 
 			wg.Add(1)
 			go func() {
-				_, err = tinysl.Get[nameService](ctx1, sl)
+				_, err = tinysl.Get[NameService](ctx1, sl)
 
 				Expect(err).ShouldNot(HaveOccurred())
 				wg.Done()
@@ -312,21 +312,21 @@ var _ = Describe("ServiceLocator", func() {
 			ctx1, cancel1 := context.WithCancel(ctx1)
 			ctx2, cancel2 := context.WithCancel(ctx1)
 
-			var hero1, hero2, hero3 *hero
+			var hero1, hero2, hero3 *Hero
 
-			hero1, err = tinysl.Get[*hero](ctx1, sl)
-
-			Expect(err).ShouldNot(HaveOccurred())
-
-			hero2, err = tinysl.Get[*hero](ctx2, sl)
+			hero1, err = tinysl.Get[*Hero](ctx1, sl)
 
 			Expect(err).ShouldNot(HaveOccurred())
 
-			hero3, err = tinysl.Get[*hero](ctx1, sl)
+			hero2, err = tinysl.Get[*Hero](ctx2, sl)
 
 			Expect(err).ShouldNot(HaveOccurred())
 
-			_, err = tinysl.Get[nameService](ctx1, sl)
+			hero3, err = tinysl.Get[*Hero](ctx1, sl)
+
+			Expect(err).ShouldNot(HaveOccurred())
+
+			_, err = tinysl.Get[NameService](ctx1, sl)
 
 			Expect(err).ShouldNot(HaveOccurred())
 
@@ -357,7 +357,7 @@ var _ = Describe("ServiceLocator", func() {
 	})
 
 	It("should return error if constructor returned error", func() {
-		errConstructor := func() (nameService, error) {
+		errConstructor := func() (NameService, error) {
 			return nil, errors.New("some unfortunate error")
 		}
 		sl, err := tinysl.
@@ -372,7 +372,7 @@ var _ = Describe("ServiceLocator", func() {
 
 		defer cancel()
 
-		_, err = tinysl.Get[*hero](ctx, sl)
+		_, err = tinysl.Get[*Hero](ctx, sl)
 
 		Expect(err).Should(HaveOccurred())
 		Expect(err).Should(BeAssignableToTypeOf(new(tinysl.ServiceBuilderError)))
@@ -381,5 +381,68 @@ var _ = Describe("ServiceLocator", func() {
 
 		Expect(err).Should(BeAssignableToTypeOf(new(tinysl.ConstructorError)))
 		Expect(errors.Unwrap(err)).Should(MatchError("some unfortunate error"))
+	})
+
+	It("should work with T", func() {
+		sl, err := tinysl.
+			Add(tinysl.Transient, nameServiceConstructor).
+			Add(tinysl.PerContext, tinysl.T[ServiceWithPublicFields]).
+			ServiceLocator()
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		ctx := context.TODO()
+		ctx, cancel := context.WithCancel(ctx)
+
+		defer cancel()
+
+		service, err := tinysl.Get[ServiceWithPublicFields](ctx, sl)
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(service.SomeProperty()).To(BeEmpty())
+		Expect(service.Name()).To(Equal("Bob"))
+	})
+
+	It("should work with P", func() {
+		sl, err := tinysl.
+			Add(tinysl.Transient, nameServiceConstructor).
+			Add(tinysl.PerContext, tinysl.P[ServiceWithPublicFields]).
+			ServiceLocator()
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		ctx := context.TODO()
+		ctx, cancel := context.WithCancel(ctx)
+
+		defer cancel()
+
+		service, err := tinysl.Get[*ServiceWithPublicFields](ctx, sl)
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(service.SomeProperty()).To(BeEmpty())
+		Expect(service.Name()).To(Equal("Bob"))
+	})
+
+	It("should work with I", func() {
+		sl, err := tinysl.
+			Add(tinysl.Transient, nameServiceConstructor).
+			Add(tinysl.PerContext, tinysl.I[HelloService, ServiceWithPublicFields]).
+			ServiceLocator()
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		ctx := context.TODO()
+		ctx, cancel := context.WithCancel(ctx)
+
+		defer cancel()
+
+		service, err := tinysl.Get[HelloService](ctx, sl)
+
+		Expect(err).ShouldNot(HaveOccurred())
+
+		Expect(service.Hello()).To(Equal("Hello Bob"))
+		Expect(service.(*ServiceWithPublicFields).SomeProperty()).To(BeEmpty())
 	})
 })

--- a/tinsl_bench_test.go
+++ b/tinsl_bench_test.go
@@ -16,7 +16,7 @@ func BenchmarkGetTransinet(b *testing.B) {
 	sl, _ := tinysl.Add(tinysl.Transient, nameServiceConstructor).ServiceLocator()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = tinysl.Get[nameService](ctx, sl)
+		_, _ = tinysl.Get[NameService](ctx, sl)
 	}
 }
 
@@ -29,7 +29,7 @@ func BenchmarkGetPerContext(b *testing.B) {
 	sl, _ := tinysl.Add(tinysl.PerContext, nameServiceConstructor).ServiceLocator()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = tinysl.Get[nameService](ctx, sl)
+		_, _ = tinysl.Get[NameService](ctx, sl)
 	}
 }
 
@@ -42,6 +42,6 @@ func BenchmarkGetSingleton(b *testing.B) {
 	sl, _ := tinysl.Add(tinysl.Singleton, nameServiceConstructor).ServiceLocator()
 
 	for i := 0; i < b.N; i++ {
-		_, _ = tinysl.Get[nameService](ctx, sl)
+		_, _ = tinysl.Get[NameService](ctx, sl)
 	}
 }


### PR DESCRIPTION
## Motivation

Most of the time service is just a struct or a pointer to a struct that may or may not implement a particular interface.
Dependencies in that case are injected as properties. This PR intends to automate this process.

## Implementation

 * `tinysl.T[Type]` is a `Type` constructor
 * `tinysl.P[Type]` is a `*Type` constructor 
 * `tinysl.I[Interface, Type]` is a `Inteface` implemented by `*Type` constructor